### PR TITLE
Use the url to key the query params to avoid routing conflicts

### DIFF
--- a/src/Controller/Component/QueryParamPreserverComponent.php
+++ b/src/Controller/Component/QueryParamPreserverComponent.php
@@ -44,19 +44,22 @@ class QueryParamPreserverComponent extends Component {
     {
         $request = $this->getController()->request;
         $query = $request->getQueryParams();
-        $ignoreParams = $this->getConfig('ignoreParams');
-        if (!empty($ignoreParams)) {
-            foreach ($ignoreParams as $param) {
-                if (isset($query[$param])) {
-                    unset($query[$param]);
+
+        if ($query) {
+            $ignoreParams = $this->getConfig('ignoreParams');
+            if (!empty($ignoreParams)) {
+                foreach ($ignoreParams as $param) {
+                    if (isset($query[$param])) {
+                        unset($query[$param]);
+                    }
                 }
             }
-        }
 
-        $request->session()->write(
-            $this->_hashKey(),
-            $query
-        );
+            $request->session()->write(
+                $this->_hashKey(),
+                $query
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Resolves #7 

I tried to use the `_matchedRoute` parameter, but I found that it would pickup default routes such as `/:controller/:action` which wasn't ideal. So instead I used the actual url instead, which sidesteps the need to process the routing in any way, and also preserves plugins, and routing urls.

Hope it's helpful. I have not run the test suite against these changes as I was working in an extending component.