### PR TITLE
Fixed coding standards

### DIFF
--- a/src/Controller/Component/QueryParamPreserverComponent.php
+++ b/src/Controller/Component/QueryParamPreserverComponent.php
@@ -58,7 +58,7 @@ class QueryParamPreserverComponent extends Component {
                 }
             }
 
-            $request->getSession()->write(
+            $request->session()->write(
                 $this->_hashKey(),
                 $query
             );
@@ -85,11 +85,11 @@ class QueryParamPreserverComponent extends Component {
         $request = $this->getController()->request;
         $key = $this->_hashKey();
 
-        if (empty($request->getQuery()) && $request->getSession()->check($key)) {
-            if(!empty($request->getSession()->read($key))) {
+        if (empty($request->getQuery()) && $request->session()->check($key)) {
+            if(!empty($request->session()->read($key))) {
                 return $this->getController()->redirect(
                     $key
-                    . '?' . http_build_query($request->getSession()->read($key))
+                    . '?' . http_build_query($request->session()->read($key))
                 );
             }
         }
@@ -122,7 +122,7 @@ class QueryParamPreserverComponent extends Component {
         if (isset($params[$ignoreParam])) {
             unset($params[$ignoreParam]);
 
-            $request->getSession()->delete($this->_hashKey());
+            $request->session()->delete($this->_hashKey());
 
             return $this->getController()->redirect($this->_hashKey());
         }

--- a/src/Controller/Component/QueryParamPreserverComponent.php
+++ b/src/Controller/Component/QueryParamPreserverComponent.php
@@ -9,14 +9,15 @@ use Cake\Controller\Component;
  * @copyright 2016 PSA Publishers Ltd.
  * @license MIT
  */
-class QueryParamPreserverComponent extends Component {
+class QueryParamPreserverComponent extends Component
+{
 
     /**
      * Default Config
      *
      * @var array
      */
-    public $_defaultConfig = [
+    protected $_defaultConfig = [
         'autoApply' => true,
         'actions' => [],
         'ignoreParams' => [],
@@ -86,10 +87,9 @@ class QueryParamPreserverComponent extends Component {
         $key = $this->_hashKey();
 
         if (empty($request->getQuery()) && $request->session()->check($key)) {
-            if(!empty($request->session()->read($key))) {
+            if (!empty($request->session()->read($key))) {
                 return $this->getController()->redirect(
-                    $key
-                    . '?' . http_build_query($request->session()->read($key))
+                    $key . '?' . http_build_query($request->session()->read($key))
                 );
             }
         }
@@ -114,7 +114,8 @@ class QueryParamPreserverComponent extends Component {
      *
      * @return \Cake\Http\Response|null
      */
-    protected function _autoApply() {
+    protected function _autoApply()
+    {
         $request = $this->getController()->request;
         $params = $request->getQueryParams();
         $ignoreParam = $this->getConfig('disablePreserveWithParam');

--- a/tests/TestCase/Controller/Component/QueryParamPreserverComponentTest.php
+++ b/tests/TestCase/Controller/Component/QueryParamPreserverComponentTest.php
@@ -13,7 +13,8 @@ use Psa\QueryParamPreserver\Controller\Component\QueryParamPreserverComponent;
  * @copyright 2016 PSA Publishers Ltd.
  * @license MIT
  */
-class QueryParamPreserverComponentTest extends TestCase {
+class QueryParamPreserverComponentTest extends TestCase
+{
 
     /**
      * Query Param Preserver Component
@@ -42,7 +43,8 @@ class QueryParamPreserverComponentTest extends TestCase {
     /**
      * @inheritDoc
      */
-    public function tearDown() {
+    public function tearDown()
+    {
         parent::tearDown();
     }
 
@@ -53,7 +55,6 @@ class QueryParamPreserverComponentTest extends TestCase {
      */
     public function testPreserve()
     {
-
     }
 
     /**
@@ -63,6 +64,5 @@ class QueryParamPreserverComponentTest extends TestCase {
      */
     public function testApply()
     {
-
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,14 +2,14 @@
 use Cake\Core\Plugin;
 
 $findRoot = function ($root) {
-	do {
-		$lastRoot = $root;
-		$root = dirname($root);
-		if (is_dir($root . '/vendor/cakephp/cakephp')) {
-			return $root;
-		}
-	} while ($root !== $lastRoot);
-	throw new \Exception('Cannot find the root of the application, unable to run tests');
+    do {
+        $lastRoot = $root;
+        $root = dirname($root);
+        if (is_dir($root . '/vendor/cakephp/cakephp')) {
+            return $root;
+        }
+    } while ($root !== $lastRoot);
+    throw new \Exception('Cannot find the root of the application, unable to run tests');
 };
 
 $root = $findRoot(__FILE__);


### PR DESCRIPTION
I noticed that the plugin does not pass the CakePHP coding standards, so this pull request aims to fix that by running the automated fixing process `phpcbf` and also a few minor manual fixes.