### PR TITLE
Replace deprecated method call with non-deprecated one

### DIFF
--- a/src/Controller/Component/QueryParamPreserverComponent.php
+++ b/src/Controller/Component/QueryParamPreserverComponent.php
@@ -59,7 +59,7 @@ class QueryParamPreserverComponent extends Component
                 }
             }
 
-            $request->session()->write(
+            $request->getSession()->write(
                 $this->_hashKey(),
                 $query
             );
@@ -123,7 +123,7 @@ class QueryParamPreserverComponent extends Component
         if (isset($params[$ignoreParam]) && (bool)$params[$ignoreParam] === false) {
             unset($params[$ignoreParam]);
 
-            $request->session()->delete($this->_hashKey());
+            $request->getSession()->delete($this->_hashKey());
 
             return $this->getController()->redirect($this->_hashKey());
         }


### PR DESCRIPTION
It appears `session()` has been deprecated since CakePHP 3.5.0, and this
project requires at least CakePHP 3.6. This PR brings session accessing
in line with CakePHP 3.5+